### PR TITLE
interface 참조 경로 오류 수정 및 문서 보완

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,17 @@ openapi-generated 폴더가 생성되었음을 확인할 수 있습니다.
 
 `./gradlew :api-mockserver:run`
 
-
+http://localhost:8085/apis/orders 에 접속하여 Mock Server 가 동작함을 확인할 수 있습니다.
 
 ## How to run App
 
 ` ./gradlew :app:bootRun` 
+
+http://localhost:8080/apis/orders 에 접속하여 App 이 동작함을 확인할 수 있습니다.
+
+> 주의!
+>
+> api-codegen build 를 먼저 실행 후, app 모듈의 코드를 실행해야만 합니다.
 
 ###### 
 

--- a/app/src/main/java/com/likelen/openapi/controller/OrderController.java
+++ b/app/src/main/java/com/likelen/openapi/controller/OrderController.java
@@ -1,7 +1,7 @@
 package com.likelen.openapi.controller;
 
-import com.likelen.openapi_demo.apis.OrderApi;
-import com.likelen.openapi_demo.models.SubscriptionOrdersModel;
+import com.likelen.openapi.apis.OrderApi;
+import com.likelen.openapi.models.SubscriptionOrdersModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 


### PR DESCRIPTION
안녕하세요! 인프콘2023 강연 인상깊게 잘 들었습니다.

예제 프로젝트 실행 시 오류가 발생하여 확인해 보니, 생성된 openapi 코드 참조가 잘못 되어있는 것으로 확인하여 수정하였습니다.
```diff
- import com.likelen.openapi_demo.apis.OrderApi;
- import com.likelen.openapi_demo.models.SubscriptionOrdersModel;
+ import com.likelen.openapi.apis.OrderApi;
+ import com.likelen.openapi.models.SubscriptionOrdersModel;
```

또한 Mockserver 실행 시 어떤 포트에서 실행되고 있는지 README만 보고 알기 어려웠다고 느껴져서
Server 실행 시 확인 절차를 README에 보완하였습니다.

수정 후 실행 시 잘 동작하는 것으로 확인하였습니다.
감사합니다 :)